### PR TITLE
X-Postal-Threat header set to be true

### DIFF
--- a/app/jobs/unqueue_message_job.rb
+++ b/app/jobs/unqueue_message_job.rb
@@ -129,7 +129,8 @@ class UnqueueMessageJob < Postal::Job
                     "X-Postal-Spam: #{queued_message.message.spam == 1 ? 'yes' : 'no'}",
                     "X-Postal-Spam-Threshold: #{queued_message.server.spam_threshold}",
                     "X-Postal-Spam-Score: #{queued_message.message.spam_score}",
-                    "X-Postal-Threat: #{queued_message.message.threat == 1 ? 'yes' : 'no'}"
+                    "X-Postal-Threat: #{queued_message.message.threat ? 'yes' : 'no'}",
+                    "X-Virus-Status: #{queued_message.message.threat_details}"
                   )
                   log "#{log_prefix} Message inspected successfully. Headers added."
                 end


### PR DESCRIPTION
To have the X-Postal-Threat header set to be true if ClamAV finds a Threat, one Line has to be changed in /app/jobs/unqueue_message_job.rb Line 132

Old: "X-Postal-Threat: #{queued_message.message.threat == 1 ? 'yes' : 'no'}"
New: "X-Postal-Threat: #{queued_message.message.threat ? 'yes' : 'no'}"

The Problem is, that the mail inspection returns "true" or "false" not 1 or 0

Additionaly, an extra header should be added:

"X-Virus-Status: #{queued_message.message.threat_details}"